### PR TITLE
Clean Code with Rubocop linter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
---require spec_helper
 --require rails_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,7 @@ AllCops:
   Exclude:
     - db/schema.rb
     - bin/bundle
+  NewCops: enable
 
 Layout/LineLength:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,8 @@ gem 'rails', '~> 6.1.4'
 gem 'pg', '~> 1.1'
 # Use Puma as the app server
 gem 'devise', '~> 4.8.0'
-gem 'devise_token_auth', '~> 1.1.5'
+# https://github.com/lynndylanhurley/devise_token_auth/issues/1474#issuecomment-860803568
+gem 'devise_token_auth', github: 'lynndylanhurley/devise_token_auth', branch: 'master'
 gem 'puma', '~> 5.0'
 gem 'rack-cors', '~> 1.1.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/lynndylanhurley/devise_token_auth.git
+  revision: 4c5245b88b39c1bb305e0cbdbfc2513eebdeda93
+  branch: master
+  specs:
+    devise_token_auth (1.2.0)
+      bcrypt (~> 3.0)
+      devise (> 3.5.2, < 5)
+      rails (>= 4.2.0, < 6.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -75,10 +85,6 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
-    devise_token_auth (1.1.5)
-      bcrypt (~> 3.0)
-      devise (> 3.5.2, < 5)
-      rails (>= 4.2.0, < 6.2)
     diff-lcs (1.4.4)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -232,7 +238,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   byebug
   devise (~> 4.8.0)
-  devise_token_auth (~> 1.1.5)
+  devise_token_auth!
   dotenv-rails (~> 2.7.6)
   factory_bot_rails (~> 6.2.0)
   faker (~> 2.18.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   namespace :api do
-    namespace :v1, defaults: { format: :json } do
+    namespace :v1, defaults: { format: :json } do # TODO: implement new routes later
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe User do
   describe 'Validations' do
     subject { build :user }

--- a/spec/requests/api/v1/sessions/create_spec.rb
+++ b/spec/requests/api/v1/sessions/create_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'POST api/v1/users/sign_in', type: :request do
   let(:password) { 'password' }
   let(:user) { create(:user, password: password) }

--- a/spec/requests/api/v1/user/create_spec.rb
+++ b/spec/requests/api/v1/user/create_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe 'POST api/v1/users/', type: :request do
   let(:user)            { User.last }
   let(:failed_response) { 422 }

--- a/spec/routing/registrations_routing_spec.rb
+++ b/spec/routing/registrations_routing_spec.rb
@@ -1,5 +1,3 @@
-require 'rails_helper'
-
 describe Api::V1::RegistrationsController, type: :routing do
   describe 'routing' do
     it 'routes to #create' do


### PR DESCRIPTION
Feature

**Feature Code:** 4
[#4](https://github.com/rootstrap/rs-blackmarket/issues/4)

**Description:**
- Removed `require 'rails_helper'` from each spec file and included it in `.rspec.yml` file.
- Changing `devise_token_auth` gem version due to deprecation warnings when specs are running.

**Notes:**
In this URL mentions deprecation warnings mitigation: https://github.com/lynndylanhurley/devise_token_auth/issues/1474#issuecomment-860803568 